### PR TITLE
Done handling for pathname undefined

### DIFF
--- a/lib/fastagi.js
+++ b/lib/fastagi.js
@@ -15,6 +15,10 @@ const createApplication = function() {
     // Read path from channel data and run matching callback
     server.on('connection', (data) => {
 
+      //pathname is undefined
+      if (!data.agi_request) {
+        return;
+      }
       // pathname has root path without search params
       const agiUrl = url.parse(data.agi_request);
       const path = agiUrl.pathname;


### PR DESCRIPTION
When it comes undefined in the parameter "data.agi_request" it is causing failure in the library.