### PR TITLE
Fixing exec command on channel.js

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -47,8 +47,8 @@ const channelActions = {
   getVariable(name) {
     return this.command(`GET VARIABLE "${name}"`);
   },
-  exec(application, optione) {
-    return this.command(`EXEC "${application} ${options}"`);
+  exec(application, options) {
+    return this.command(`EXEC "${application}" "${options}"`);
   },
   verbose(message, level = 3) {
     return this.command(`VERBOSE "${message}" "${level}"`);


### PR DESCRIPTION
### Issue
When using the library and attempting to make a dial, I encountered an error due to these inconsistencies:
- The function `exec` received arguments `application` and `optione`, but used the variable `options` internally.
- Missing quotes around the variables `application` and `optione`.

### Changes Made
- Corrected the variable name from `optione` to `options`.
- Added missing quotes around the variables `application` and `options`.


If you have any questions or need further clarification, please let me know.

Thank you for considering my contribution!